### PR TITLE
add manual support for ESM in NodeJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ The [Stencil documentation](https://stenciljs.com/docs/overview) provide example
 
 ### NodeJS
 
-Due to an [open issue in Stencil regarding ESM entry points](https://github.com/ionic-team/stencil/issues/2826), ESM resolution support in NodeJS for this package has been manually fixed by overriding the `module` field in _package.json_.  As long as your dev server / bundler supports the `module` fields, you should be able to load the JS for the component like this:
+Due to an [open issue in Stencil regarding ESM entry points](https://github.com/ionic-team/stencil/issues/2826), ESM resolution support in NodeJS for this package has been manually fixed by overriding the `module` field in _package.json_.  As long as your dev server / bundler supports the `module` field, you should be able to `import` the component like this:
 ```js
 import 'web-social-share';
 ```
 
-> Note: as noted in the linked issue, one caveate is that this entry file uses template literals inside dynamic imports (e.g. `import(${x})`) so make sure this feature also supported by your environemt.  For example, Rollup has [**@rollup/plugin-dynamic-import-vars**](https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars).  See [this issue](https://github.com/peterpeterparker/web-social-share/issues/48) for more info.
+> _Note: as noted in the linked issue, one caveat is that this entry file uses template literals inside dynamic imports (e.g. `import(${x})`) so make sure this syntax is also supported by your environment.  For example, Rollup has [**@rollup/plugin-dynamic-import-vars**](https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars).
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ This Web Component is developed with [Stencil](https://stenciljs.com).
 
 The [Stencil documentation](https://stenciljs.com/docs/overview) provide examples of Javascript and framework integration for [Angular](https://stenciljs.com/docs/angular), [React](https://stenciljs.com/docs/react), [Vue](https://stenciljs.com/docs/vue) and [Ember](https://stenciljs.com/docs/ember).
 
+### NodeJS
+
+Due to an [open issue in Stencil regarding ESM entry points](https://github.com/ionic-team/stencil/issues/2826), ESM resolution support in NodeJS for this package has been manually fixed by overriding the `module` field in _package.json_.  As long as your dev server / bundler supports the `module` fields, you should be able to load the JS for the component like this:
+```js
+import 'web-social-share';
+```
+
+> Note: as noted in the linked issue, one caveate is that this entry file uses template literals inside dynamic imports (e.g. `import(${x})`) so make sure this feature also supported by your environemt.  For example, Rollup has [**@rollup/plugin-dynamic-import-vars**](https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars).  See [this issue](https://github.com/peterpeterparker/web-social-share/issues/48) for more info.
+
 ## Getting Started
 
 The Web Social Share Component can be use like following:

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.0.0",
   "description": "A Web Component to share urls and text on social networks",
   "main": "dist/index.cjs.js",
-  "module": "dist/index.js",
+  "module": "dist/websocialshare/websocialshare.esm.js",
   "es2015": "dist/esm/index.js",
   "es2017": "dist/esm/index.js",
   "jsnext:main": "dist/esm/index.js",


### PR DESCRIPTION
resolves #48 

1. Override `module` field in _package.json_ to point to a non empty file ([_dist/websocialshare/websocialshare.esm.js_](https://unpkg.com/browse/web-social-share@8.0.0/dist/websocialshare/websocialshare.esm.js))
1. Update README with docs for NodeJS / ESM support

----

Question:
Although these fields are all community driven / not NodeJS "speced", wondering what do about them in _package.json_, since they were also all pointing at the same empty file?
-  `"es2015"`
-  `"es2017"`
-  `"jsnext:main"`

Ultimately it's up to tooling authors to support them, but from my experience, I think I've only really seen `module` catch on so far, otherwise I think [_export maps_](https://nodejs.org/api/packages.html#main-entry-point-export) are the way to go (and so hopefully Stencil will support this too 🤞 )