### PR TITLE
experimentalImportInjection will be removed in a future major version of Stencil.

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -29,6 +29,6 @@ export const config: Config = {
     })
   ],
   extras: {
-    experimentalImportInjection: true
+    enableImportInjection: true
   }
 };


### PR DESCRIPTION
Renaming the setting to enableImportInjection